### PR TITLE
Failing because of `ReferenceError: bigInt is not defined`

### DIFF
--- a/BigRational.js
+++ b/BigRational.js
@@ -1,5 +1,6 @@
 ;var bigRat = (function () {
     "use strict";
+    var bigInt;
     if (typeof require === "function") {
         bigInt = require("big-integer");
     }


### PR DESCRIPTION
In strict mode `var bigInt` is required.
